### PR TITLE
Upgrade to Java 21 and bump all dependencies/plugins

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.0/apache-maven-3.9.0-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -67,39 +67,40 @@ the License.
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <minimum-required-maven.version>3.6.3</minimum-required-maven.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <lombok.version>1.18.34</lombok.version>
+    <lombok.version>1.18.44</lombok.version>
     <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
     <delombok.output>target/lombok-generated</delombok.output>
-    <owasp-dependency-check.version>10.0.4</owasp-dependency-check.version>
+    <owasp-dependency-check.version>12.2.0</owasp-dependency-check.version>
     <dependency-check.skip>false</dependency-check.skip>
-    <junit.jupiter.version>5.11.0</junit.jupiter.version>
-    <sure-fire-plugin.version>3.5.0</sure-fire-plugin.version>
-    <surefire-junit5-tree-reporter.version>1.3.0</surefire-junit5-tree-reporter.version>
+    <junit.jupiter.version>5.14.2</junit.jupiter.version>
+    <!-- Pinned to 3.5.3: surefire-junit5-tree-reporter is incompatible with 3.5.4+ -->
+    <sure-fire-plugin.version>3.5.3</sure-fire-plugin.version>
+    <surefire-junit5-tree-reporter.version>1.5.1</surefire-junit5-tree-reporter.version>
     <jacoco.skip>false</jacoco.skip>
-    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
     <jacoco-min-coverage.ratio>0.80</jacoco-min-coverage.ratio>
     <jacoco-missed-classes.count>0</jacoco-missed-classes.count>
-    <checkstyle-plugin.version>3.5.0</checkstyle-plugin.version>
-    <checkstyle.version>10.18.1</checkstyle.version>
+    <checkstyle-plugin.version>3.6.0</checkstyle-plugin.version>
+    <checkstyle.version>10.21.1</checkstyle.version>
     <checkstyle.skip>false</checkstyle.skip>
     <checkstyle.maxAllowedViolations>0</checkstyle.maxAllowedViolations>
     <checkstyle.violationSeverity>error</checkstyle.violationSeverity>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <checkstyle.consoleOutput>true</checkstyle.consoleOutput>
     <release-commit-prefix>[skip ci]</release-commit-prefix>
-    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
-    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
-    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <maven-versions-plugin.version>2.17.1</maven-versions-plugin.version>
+    <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+    <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+    <maven-versions-plugin.version>2.21.0</maven-versions-plugin.version>
     <maven-sortpom-plugin.version>4.0.0</maven-sortpom-plugin.version>
-    <fmt-maven-plugin.version>2.24</fmt-maven-plugin.version>
-    <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
+    <fmt-maven-plugin.version>2.27.0</fmt-maven-plugin.version>
+    <maven-gpg-plugin.version>3.2.6</maven-gpg-plugin.version>
     <gpg.skip>false</gpg.skip>
   </properties>
   

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,7 @@ the License.
       </plugin>
     </plugins>
   </build>
+  
   <reporting>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ the License.
     <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
     <maven-versions-plugin.version>2.21.0</maven-versions-plugin.version>
     <maven-sortpom-plugin.version>4.0.0</maven-sortpom-plugin.version>
-    <fmt-maven-plugin.version>2.27.0</fmt-maven-plugin.version>
+    <fmt-maven-plugin.version>2.27</fmt-maven-plugin.version>
     <maven-gpg-plugin.version>3.2.6</maven-gpg-plugin.version>
     <gpg.skip>false</gpg.skip>
   </properties>


### PR DESCRIPTION
- Set java.version to 21 with compiler source/target aligned
- lombok: 1.18.34 -> 1.18.44
- owasp-dependency-check: 10.0.4 -> 12.2.0 (mandatory NVD API upgrade)
- junit-jupiter: 5.11.0 -> 5.14.2
- maven-surefire-plugin: 3.5.0 -> 3.5.3 (pinned; 3.5.4+ breaks tree reporter)
- surefire-junit5-tree-reporter: 1.3.0 -> 1.5.1
- jacoco-maven-plugin: 0.8.12 -> 0.8.14
- maven-checkstyle-plugin: 3.5.0 -> 3.6.0
- checkstyle: 10.18.1 -> 10.21.1
- maven-release-plugin: 3.1.1 -> 3.3.1
- maven-source-plugin: 3.3.1 -> 3.4.0
- maven-javadoc-plugin: 3.10.0 -> 3.12.0
- maven-enforcer-plugin: 3.5.0 -> 3.6.2
- maven-versions-plugin: 2.17.1 -> 2.21.0
- fmt-maven-plugin: 2.24 -> 2.27
- maven-gpg-plugin: 3.2.5 -> 3.2.6
- Maven wrapper: 3.9.0 -> 3.9.14